### PR TITLE
Update top-pypi-packages filename

### DIFF
--- a/scrap_data.py
+++ b/scrap_data.py
@@ -12,7 +12,7 @@ all_start_packages = ["tomni", "neo4j"]
 deps_on = []
 
 response = requests.get(
-    r"https://hugovk.github.io/top-pypi-packages/top-pypi-packages-30-days.min.json"
+    r"https://hugovk.github.io/top-pypi-packages/top-pypi-packages.min.json"
 )
 top5000 = response.json()["rows"]
 


### PR DESCRIPTION
To stay within quota, it now has just under 30 days of data, so the filename has been updated. Both will be available for a while. See https://github.com/hugovk/top-pypi-packages/pull/46.